### PR TITLE
update vendordep json to include frcYear, needed for 2024

### DIFF
--- a/src/generate/SuperCORE.json
+++ b/src/generate/SuperCORE.json
@@ -2,6 +2,7 @@
     "fileName": "SuperCORE.json",
     "name": "SuperCORE",
     "version": "${pubVersion}",
+    "frcYear": 2024,
     "uuid": "f82a9412-6f53-4bc0-960c-6895a5236f57",
     "mavenUrls": [
         "https://frcteam3255.github.io/SuperCORE/releases/"


### PR DESCRIPTION
2024 Vendor Libraries require the new frcYear field be provided