### PR TITLE
Fix simulated vs real angle mismatches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v4.1.7
+    - uses: actions/checkout@v2
 
     # Grant execute permission for gradlew
     - name: Grant execute permission for gradlew
@@ -38,7 +38,7 @@ jobs:
       run: ./gradlew :spotlessApply
 
     # Commits formatting changes
-    - uses: stefanzweifel/git-auto-commit-action@v5.0.1
+    - uses: stefanzweifel/git-auto-commit-action@v4
       with:
         commit_message: Formatted Code
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.1.7
 
     # Grant execute permission for gradlew
     - name: Grant execute permission for gradlew

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       run: ./gradlew :spotlessApply
 
     # Commits formatting changes
-    - uses: stefanzweifel/git-auto-commit-action@v5
+    - uses: stefanzweifel/git-auto-commit-action@v5.0.1
       with:
         commit_message: Formatted Code
 

--- a/src/main/java/com/frcteam3255/components/swerve/SN_SuperSwerve.java
+++ b/src/main/java/com/frcteam3255/components/swerve/SN_SuperSwerve.java
@@ -372,6 +372,7 @@ public class SN_SuperSwerve extends SubsystemBase {
 	 *            The pose you would like to reset the pose estimator to
 	 */
 	public void resetPoseToPose(Pose2d pose) {
+		resetYaw(pose.getRotation().getDegrees());
 		swervePoseEstimator.resetPosition(getRotation(), getModulePositions(), pose);
 	}
 

--- a/src/main/java/com/frcteam3255/components/swerve/SN_SuperSwerve.java
+++ b/src/main/java/com/frcteam3255/components/swerve/SN_SuperSwerve.java
@@ -28,6 +28,7 @@ import edu.wpi.first.math.kinematics.SwerveModulePosition;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
+import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -400,6 +401,10 @@ public class SN_SuperSwerve extends SubsystemBase {
 	 * Resets the Yaw of the Pigeon to 0
 	 */
 	public void resetYaw() {
+		if (isSimulation) {
+			simAngle = 0;
+		}
+
 		pigeon.setYaw(0);
 	}
 
@@ -410,6 +415,10 @@ public class SN_SuperSwerve extends SubsystemBase {
 	 *            The yaw (in degrees) to reset the Pigeon to
 	 */
 	public void resetYaw(double yaw) {
+		if (isSimulation) {
+			simAngle = Units.degreesToRadians(yaw);
+		}
+
 		pigeon.setYaw(yaw);
 	}
 


### PR DESCRIPTION
Fixes the bug where the value of `simAngle` (the pigeon's simulated angle) would not match the value of the Pose Estimator's rotation.

I didn't convert the variable to a `Measure<Angle>` as I figured that would cause more problems right now. I think that converting everything into measures should just be one giant pr instead, with its own dedicated testing. I would prefer if this could be tested on a real bot, as the changes to the `resetPoseToPose` method _may_ mess with autos (though I doubt it).